### PR TITLE
Add interactive waves and building

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,22 @@
     <meta charset="UTF-8">
     <title>Tower Defense Demo</title>
     <style>
-        body { margin: 0; font-family: sans-serif; }
+        body { margin: 0; font-family: sans-serif; background:#000; color:#fff; }
+        #ui {
+            text-align: center;
+            padding: 4px;
+            background: #222;
+        }
         canvas { background: #111; display: block; margin: auto; }
     </style>
 </head>
 <body>
+    <div id="ui">
+        Gold: <span id="gold"></span>
+        Lives: <span id="lives"></span>
+        Wave: <span id="wave"></span>
+        <button id="startWave">Start Wave</button>
+    </div>
     <canvas id="game" width="640" height="480"></canvas>
     <script src="app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add overlay UI for gold, lives and waves
- implement tower building on click with a simple economy
- create a zigzag path and wave spawner
- track lives and allow starting waves via button

## Testing
- `node -c app.js`

------
https://chatgpt.com/codex/tasks/task_e_68417d4aed148333b280e3bcb97307f0