### PR TITLE
Add emoji towers and upgrade features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tower Defense
 
-This repository contains a very small tower defense demo written in vanilla JavaScript. Open `index.html` in a modern browser to play.
+This repository contains a very small emoji based tower defense demo written in vanilla JavaScript. Open `index.html` in a modern browser to play.
 
 ## How to run
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,23 @@
         Gold: <span id="gold"></span>
         Lives: <span id="lives"></span>
         Wave: <span id="wave"></span>
+        <span id="countdown"></span>
         <button id="startWave">Start Wave</button>
+        <select id="towerType">
+            <option value="crossbow">🏹</option>
+            <option value="tank">🚓</option>
+            <option value="mortar">💣</option>
+        </select>
+        <button id="pauseBtn">Pause</button>
+        <button id="saveBtn">Save</button>
+        <button id="loadBtn">Load</button>
+    </div>
+    <div id="upgradeMenu" style="display:none;background:#333;padding:4px;text-align:center;">
+        <div>Upgrade Tower</div>
+        <button data-up="damage">Damage</button>
+        <button data-up="speed">Speed</button>
+        <button data-up="range">Range</button>
+        <button id="closeUpgrade">Close</button>
     </div>
     <canvas id="game" width="640" height="480"></canvas>
     <script src="app.js"></script>


### PR DESCRIPTION
## Summary
- enhance UI to select tower types and pause or save
- reimplement game logic with emoji towers, enemies and bullets
- allow upgrading towers via upgrade menu
- animate gold coins flying to balance

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_684252d3e9708333973cdd9f4cdb41cc